### PR TITLE
Fix return value for begin() via reset()

### DIFF
--- a/src/HTU21D.cpp
+++ b/src/HTU21D.cpp
@@ -154,6 +154,8 @@ bool HTU21D::reset() {
   if(_wire.read() != 0x02) return false;
   
   _resolution = RESOLUTION_RH12_T14;
+
+  return true;
 }
 
 /**


### PR DESCRIPTION
Calls to begin() confusingly never returned true, fix that.

Also squash warning:

    .pio/libdeps/nano/HTU21D Sensor Library/src/HTU21D.cpp: In member function 'bool HTU21D::reset()':
    .pio/libdeps/nano/HTU21D Sensor Library/src/HTU21D.cpp:159:1: warning: control reaches end of non-void function [-Wreturn-type]
     }
     ^